### PR TITLE
Upload survey Improvements

### DIFF
--- a/pyblaise/__init__.py
+++ b/pyblaise/__init__.py
@@ -1,5 +1,6 @@
 from .operations import (
     create_role,
+    get_manifest_id_from_zip,
     create_survey_manifest,
     create_survey_from_existing,
     get_auth_token,

--- a/pyblaise/operations.py
+++ b/pyblaise/operations.py
@@ -284,6 +284,29 @@ def report_user_logout(protocol, host, port, token, username):
     return R.status_code
 
 
+def get_manifest_id_from_zip(existing_survey_filename):
+    """
+    Returns the survey ID from the manifest file within provided zip file
+    """
+
+    from zipfile import ZipFile
+
+    # Import required library
+    import xml.etree.ElementTree as ET
+
+    # Find the manifest file from the ZIP
+    with ZipFile(existing_survey_filename, "r") as z_in:
+        for item in z_in.infolist():
+            if item.filename.endswith(".manifest"):
+                with z_in.open(item.filename) as file:
+                    # Read from the file
+                    manifest_file = file.read().decode("utf-8")
+                    # Convert file to xml Element
+                    root = ET.fromstring(manifest_file)
+                    return root.attrib["ID"]
+    return None
+
+
 def create_survey_manifest(survey_name):
     from uuid import uuid4
 

--- a/pyblaise/upload_survey.py
+++ b/pyblaise/upload_survey.py
@@ -1,19 +1,19 @@
 import requests
 from .soap_utils import build_uri
 
-REQUEST_PATH = "/Blaise/Administer/Services/REST/ftf/OPN2004A/8a2d121e-6dba-4bf5-a6bf-d1b0e6c36160/uploadpackage"
 
-
-def upload_survey(protocol, host, port, token, filename):
+def upload_survey(protocol, host, port, server_park, survey_name, survey_id, token, filename):
     headers = {
         "Authorization": "Bearer %s" % token,
         "Content-Type": "application/binary",
         "Expect": "100-continue",
     }
 
+    REQUEST_PATH = f"/Blaise/Administer/Services/REST/{server_park}/{survey_name}/{survey_id}/uploadpackage"
+
     with open(filename, "rb") as payload:
         R = requests.post(
-            build_uri(protocol, host, port, REQUEST_PATH), headers=headers, data=payload
+            build_uri(protocol, host, port, REQUEST_PATH), headers=headers, data=payload,
         )
 
     return R.status_code


### PR DESCRIPTION
Improvements to upload survey method so that it's no longer hard coded. Add more parameters to the method to pass in the server park, survey name and survey ID for uploads to work. 

Also added the function `get_manifest_id_from_zip` which grabs the survey ID from the manifest file, from the provided survey zip, which allows the upload_survey to upload properly to blaise. 